### PR TITLE
Close CFP

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,8 +47,8 @@ registrations:
 
 program:
   # stage: call-for-proposals-will-open-soon
-  stage: call-for-proposals-open
-  # stage: call-for-proposals-closed
+  # stage: call-for-proposals-open
+  stage: call-for-proposals-closed
   # stage: program-is-ready
   url: "https://talks.osgeo.org/sotm2024-latam"
 


### PR DESCRIPTION
This changes the status of the website to `call-for-proposals-closed`.

@cyberjuan @Smarzaro once the program is ready, please provide the schedule link so I can move the website to `program-is-ready` stage.