### PR TITLE
Improve the program view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
+
 # State of the Map LATAM 2024 Website
 
-Welcome to the repository containing the source code for the State of the Map LATAM 2024 website. We're currently in the development phase, and we welcome any feedback to improve the site. If you encounter errors or have suggestions for enhancements, please feel free to open an issue.
+Welcome to the repository for the State of the Map LATAM 2024 website! If you encounter any issues or have suggestions for improvements, we encourage you to [open an issue](https://github.com/OSMLatam/sotm-latam-2024/issues).
 
-**Current Status:** Work in Progress
-
-For a sneak peek of the website, visit the [preview site](https://sotm-latam-2024.surge.sh/).
+Visit the live website at [https://2024.osmlatam.org](https://2024.osmlatam.org)
 
 ## How to Contribute
 
@@ -20,9 +19,9 @@ We encourage developers to contribute to the project. If you're interested in ma
 
 Make your changes and submit a Pull Request (PR) following [this guide](https://help.github.com/articles/using-pull-requests/).
 
-## Explore Previous Conferences
+## Explore Past Conferences
 
-Take a look back at the previous State of the Map LATAM conferences:
+Relive the experience of previous State of the Map LATAM events:
 
 - [SotM LATAM 2019](http://2019.osmlatam.org)
 - [SotM LATAM 2018](http://2018.osmlatam.org)

--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ program:
   # stage: call-for-proposals-open
   # stage: call-for-proposals-closed
   stage: program-is-ready
-  url: "https://talks.osgeo.org/sotm2024-latam/schedule"
+  url: "https://talks.osgeo.org/sotm2024-latam/talk/"
 
 sponsorship_campaign_is_open: true
 


### PR DESCRIPTION
The current program URL show the event schedule on a grid, which is hard to navigate due to the horizontal scroll. In this PR, we changed the URL to the one ending in `/talk`, which list the full program in a column.

## Before

<img width="1815" alt="Screenshot 2024-11-20 at 14 26 15" src="https://github.com/user-attachments/assets/ee57ff7d-1d7f-427e-b38e-4ef6a10b13ab">


## After

<img width="1191" alt="Screenshot 2024-11-20 at 14 24 50" src="https://github.com/user-attachments/assets/5eeac012-3f66-4915-a60b-44395dda8356">

I also added some small updates to the README.

cc @cyberjuan @smarzaro